### PR TITLE
[Fix] UIFont+ 피그마에 맞게 사용하기 쉽게 수정

### DIFF
--- a/SOLSOL/Global/Extension/UIFont+.swift
+++ b/SOLSOL/Global/Extension/UIFont+.swift
@@ -7,17 +7,50 @@
 
 import UIKit
 
+enum FontName: String {
+    case display5
+    case display5Long
+    case display4
+    case display6
+    case headline
+    case subhead4
+    case subhead3
+    case subhead2
+    case subhead2Long
+    case subhead1
+    case caption2
+    case caption1
+    case display6Light
+
+    var rawValue: String {
+        switch self {
+        case .display5: return "OneShinhan-Bold"
+        case .display5Long, .display4, .display6,
+                .headline, .subhead1, .subhead2,
+                .subhead3, .subhead4, .subhead2Long,
+                .caption1, .caption2:
+            return "OneShinhan-Medium"
+        case .display6Light: return "OneShinhan-Light"
+        }
+    }
+
+    var size: CGFloat {
+        switch self {
+        case .display5, .display5Long: return 25
+        case .display4: return 22
+        case .display6, .display6Light: return 20
+        case .headline: return 18
+        case .subhead4: return 16
+        case .subhead3: return 14
+        case .subhead2, .subhead2Long, .caption2: return 13
+        case .subhead1: return 12
+        case .caption1: return 9
+        }
+    }
+}
+
 extension UIFont {
-    
-    static func OneShinhanBold(ofSize size: CGFloat) -> UIFont{
-        return UIFont(name: "OneShinhan-Bold", size: size)!
-    }
-    
-    static func OneShinhanMedium(ofSize size: CGFloat) -> UIFont{
-        return UIFont(name: "OneShinhan-Medium", size: size)!
-    }
-    
-    static func OneShinhanLight(ofSize size: CGFloat) -> UIFont{
-        return UIFont(name: "OneShinhan-Light", size: size)!
+    static func font(_ style: FontName) -> UIFont {
+        return UIFont(name: style.rawValue, size: style.size)!
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- fix/#9

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 피그마에서는 아래표를 기준으로 폰트를 알려주고 있고 사이즈도 level에 따라 고정되어 있기 때문에 표에 맞게 사용하기 쉽게 하기 위해서 UIFont+를 수정했습니다.
<img width="819" alt="image" src="https://github.com/GO-SOPT-SOLSOL/SOLSOL-iOS/assets/60292150/412b4737-63ff-48c2-bbb3-03eb5453c7d7">
<img width="138" alt="image" src="https://github.com/GO-SOPT-SOLSOL/SOLSOL-iOS/assets/60292150/3dbbd04f-37ae-4e99-bb26-1091a28dc6c7">

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
기존의 font 메서드와 쓰는 방법이 조금 변경됐으니 참고부탁드립니다.
### 사용법
```swift
label.font = .font(.display5)
```
사이즈 따로 지정해줄 필요없이 피그마에 표시된 폰트만 넣어주면 됩니다 !

## 📟 관련 이슈
- Resolved: #9
