### PR TITLE
[Feat] #35 - Network Layer 구축

### DIFF
--- a/SOLSOL.xcodeproj/project.pbxproj
+++ b/SOLSOL.xcodeproj/project.pbxproj
@@ -61,6 +61,18 @@
 		B54F21502A13BF9D000D350C /* ProductViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54F214F2A13BF9D000D350C /* ProductViewController.swift */; };
 		B54F21522A13BFA4000D350C /* BenefitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54F21512A13BFA4000D350C /* BenefitViewController.swift */; };
 		B54F21542A13BFAA000D350C /* AllMenusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54F21532A13BFAA000D350C /* AllMenusViewController.swift */; };
+		B5D06E252A18F89B00048C72 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E242A18F89B00048C72 /* Config.swift */; };
+		B5D06E272A18F8DD00048C72 /* HTTPHeaderField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E262A18F8DD00048C72 /* HTTPHeaderField.swift */; };
+		B5D06E292A18F91700048C72 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E282A18F91700048C72 /* NetworkResult.swift */; };
+		B5D06E2B2A18F93400048C72 /* TargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E2A2A18F93400048C72 /* TargetType.swift */; };
+		B5D06E2D2A18F95000048C72 /* APIEventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E2C2A18F95000048C72 /* APIEventLogger.swift */; };
+		B5D06E312A198BEF00048C72 /* HomeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E302A198BEF00048C72 /* HomeTarget.swift */; };
+		B5D06E342A198CC500048C72 /* BaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E332A198CC500048C72 /* BaseResponse.swift */; };
+		B5D06E362A198DB900048C72 /* AccountsListRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E352A198DB900048C72 /* AccountsListRequestDTO.swift */; };
+		B5D06E3B2A198F7900048C72 /* AccountsListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E3A2A198F7900048C72 /* AccountsListResponseDTO.swift */; };
+		B5D06E3F2A19918700048C72 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E3E2A19918700048C72 /* HomeService.swift */; };
+		B5D06E412A1992B300048C72 /* APIRequestLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E402A1992B300048C72 /* APIRequestLoader.swift */; };
+		B5D06E432A19A1EE00048C72 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D06E422A19A1EE00048C72 /* NetworkService.swift */; };
 		F45A98262A17764100C10142 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45A98252A17764100C10142 /* Data.swift */; };
 		F4D6890E2A12B0C90082A9F3 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D6890D2A12B0C90082A9F3 /* UITextField+.swift */; };
 		F4D6D00A2A168F7C00B4A125 /* TransferAccountsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D6D0092A168F7C00B4A125 /* TransferAccountsTableViewCell.swift */; };
@@ -139,6 +151,18 @@
 		B54F214F2A13BF9D000D350C /* ProductViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductViewController.swift; sourceTree = "<group>"; };
 		B54F21512A13BFA4000D350C /* BenefitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenefitViewController.swift; sourceTree = "<group>"; };
 		B54F21532A13BFAA000D350C /* AllMenusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllMenusViewController.swift; sourceTree = "<group>"; };
+		B5D06E242A18F89B00048C72 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		B5D06E262A18F8DD00048C72 /* HTTPHeaderField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeaderField.swift; sourceTree = "<group>"; };
+		B5D06E282A18F91700048C72 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
+		B5D06E2A2A18F93400048C72 /* TargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetType.swift; sourceTree = "<group>"; };
+		B5D06E2C2A18F95000048C72 /* APIEventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEventLogger.swift; sourceTree = "<group>"; };
+		B5D06E302A198BEF00048C72 /* HomeTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTarget.swift; sourceTree = "<group>"; };
+		B5D06E332A198CC500048C72 /* BaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponse.swift; sourceTree = "<group>"; };
+		B5D06E352A198DB900048C72 /* AccountsListRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsListRequestDTO.swift; sourceTree = "<group>"; };
+		B5D06E3A2A198F7900048C72 /* AccountsListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsListResponseDTO.swift; sourceTree = "<group>"; };
+		B5D06E3E2A19918700048C72 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
+		B5D06E402A1992B300048C72 /* APIRequestLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequestLoader.swift; sourceTree = "<group>"; };
+		B5D06E422A19A1EE00048C72 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		F45A98252A17764100C10142 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		F4D6890D2A12B0C90082A9F3 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		F4D6D0092A168F7C00B4A125 /* TransferAccountsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAccountsTableViewCell.swift; sourceTree = "<group>"; };
@@ -195,6 +219,7 @@
 		2AC4083E2A0F6686009F0D56 /* SOLSOL */ = {
 			isa = PBXGroup;
 			children = (
+				B5D06E222A18EA4700048C72 /* Network */,
 				2AC408782A112DC1009F0D56 /* Application */,
 				2AC408792A112DE9009F0D56 /* Global */,
 				2AC408892A113006009F0D56 /* Presentation */,
@@ -460,6 +485,97 @@
 			path = TabVCs;
 			sourceTree = "<group>";
 		};
+		B5D06E222A18EA4700048C72 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E322A198C0C00048C72 /* DTO */,
+				B5D06E2E2A198B8D00048C72 /* Router */,
+				B5D06E3C2A19917000048C72 /* Service */,
+				B5D06E232A18EA8B00048C72 /* Base */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		B5D06E232A18EA8B00048C72 /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E242A18F89B00048C72 /* Config.swift */,
+				B5D06E262A18F8DD00048C72 /* HTTPHeaderField.swift */,
+				B5D06E282A18F91700048C72 /* NetworkResult.swift */,
+				B5D06E2A2A18F93400048C72 /* TargetType.swift */,
+				B5D06E2C2A18F95000048C72 /* APIEventLogger.swift */,
+				B5D06E332A198CC500048C72 /* BaseResponse.swift */,
+				B5D06E402A1992B300048C72 /* APIRequestLoader.swift */,
+				B5D06E422A19A1EE00048C72 /* NetworkService.swift */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
+		B5D06E2E2A198B8D00048C72 /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E2F2A198BE200048C72 /* Home */,
+			);
+			path = Router;
+			sourceTree = "<group>";
+		};
+		B5D06E2F2A198BE200048C72 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E302A198BEF00048C72 /* HomeTarget.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		B5D06E322A198C0C00048C72 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E372A198E3D00048C72 /* Home */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		B5D06E372A198E3D00048C72 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E382A198E6F00048C72 /* Request */,
+				B5D06E392A198E7400048C72 /* Response */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		B5D06E382A198E6F00048C72 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E352A198DB900048C72 /* AccountsListRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		B5D06E392A198E7400048C72 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E3A2A198F7900048C72 /* AccountsListResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		B5D06E3C2A19917000048C72 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E3D2A19917900048C72 /* Home */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		B5D06E3D2A19917900048C72 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				B5D06E3E2A19918700048C72 /* HomeService.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -613,24 +729,32 @@
 				B51383042A157B6700167728 /* TransferDetailViewModel.swift in Sources */,
 				2A4761082A13F0EE005BAA9F /* Item.swift in Sources */,
 				F4D6D00A2A168F7C00B4A125 /* TransferAccountsTableViewCell.swift in Sources */,
+				B5D06E2D2A18F95000048C72 /* APIEventLogger.swift in Sources */,
 				2A4761042A13EC1B005BAA9F /* NSObject+.swift in Sources */,
 				2AC408912A1131FA009F0D56 /* TransferDetailViewController.swift in Sources */,
 				B54F21462A135AE9000D350C /* SOLButton.swift in Sources */,
 				B51383012A157A1900167728 /* MyAccount.swift in Sources */,
 				B51382EC2A13CFA100167728 /* UITabBarController+.swift in Sources */,
+				B5D06E362A198DB900048C72 /* AccountsListRequestDTO.swift in Sources */,
 				2A47610A2A1538B5005BAA9F /* TransferListCollectionViewCell.swift in Sources */,
 				B54F21542A13BFAA000D350C /* AllMenusViewController.swift in Sources */,
 				F45A98262A17764100C10142 /* Data.swift in Sources */,
+				B5D06E412A1992B300048C72 /* APIRequestLoader.swift in Sources */,
+				B5D06E3F2A19918700048C72 /* HomeService.swift in Sources */,
 				2AC408442A0F6686009F0D56 /* HomeViewController.swift in Sources */,
 				B54F21442A135316000D350C /* SOLNavigationBar.swift in Sources */,
 				2A204ADF2A115BC500805E0A /* HomeView.swift in Sources */,
 				2A4761032A13EC1B005BAA9F /* UIView+.swift in Sources */,
 				2A4760FD2A13EBF1005BAA9F /* FooterButtonTableViewCell.swift in Sources */,
+				B5D06E272A18F8DD00048C72 /* HTTPHeaderField.swift in Sources */,
 				B54F21522A13BFA4000D350C /* BenefitViewController.swift in Sources */,
+				B5D06E312A198BEF00048C72 /* HomeTarget.swift in Sources */,
 				2A47610E2A154B72005BAA9F /* Transfer.swift in Sources */,
 				B51382FE2A1519FB00167728 /* NumberPadView.swift in Sources */,
 				2AC4088E2A113195009F0D56 /* TransferViewController.swift in Sources */,
+				B5D06E3B2A198F7900048C72 /* AccountsListResponseDTO.swift in Sources */,
 				2AC4087D2A112E56009F0D56 /* ImageLiterals.swift in Sources */,
+				B5D06E432A19A1EE00048C72 /* NetworkService.swift in Sources */,
 				2A4760FB2A13EBF1005BAA9F /* ShinhanPlusTableViewCell.swift in Sources */,
 				2A204AE72A115C0B00805E0A /* TransferDetailView.swift in Sources */,
 				2A4760F92A13EBF1005BAA9F /* DeliveryPackagingTableViewCell.swift in Sources */,
@@ -642,13 +766,17 @@
 				B54F214E2A13BF96000D350C /* MoneyVerseViewController.swift in Sources */,
 				B54F21492A1364F0000D350C /* SOLTabBarController.swift in Sources */,
 				2AC408402A0F6686009F0D56 /* AppDelegate.swift in Sources */,
+				B5D06E292A18F91700048C72 /* NetworkResult.swift in Sources */,
 				2A47610C2A153D82005BAA9F /* TransferList.swift in Sources */,
+				B5D06E2B2A18F93400048C72 /* TargetType.swift in Sources */,
 				2AC408422A0F6686009F0D56 /* SceneDelegate.swift in Sources */,
 				2A4761072A13F0EE005BAA9F /* Section.swift in Sources */,
+				B5D06E252A18F89B00048C72 /* Config.swift in Sources */,
 				2A4761002A13EBF1005BAA9F /* MyAccountTableViewCell.swift in Sources */,
 				B54F21502A13BF9D000D350C /* ProductViewController.swift in Sources */,
 				2AF091F02A1151A300F611C4 /* UIColor+.swift in Sources */,
 				F4D6890E2A12B0C90082A9F3 /* UITextField+.swift in Sources */,
+				B5D06E342A198CC500048C72 /* BaseResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -700,6 +828,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BASE_URL = "http://3.38.1.206/api";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -760,6 +889,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BASE_URL = "http://3.38.1.206/api";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";

--- a/SOLSOL/Global/Resources/Info.plist
+++ b/SOLSOL/Global/Resources/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>OneShinhan-Bold.otf</string>

--- a/SOLSOL/Network/Base/APIEventLogger.swift
+++ b/SOLSOL/Network/Base/APIEventLogger.swift
@@ -1,0 +1,45 @@
+//
+//  APIEventLogger.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/20.
+//
+
+import Foundation
+
+import Alamofire
+
+final class APIEventLogger: EventMonitor {
+    func requestDidFinish(_ request: Request) {
+
+        print("===========================🛰 NETWORK Reqeust LOG===========================")
+        print(request.description)
+
+        print(
+            "URL: " + (request.request?.url?.absoluteString ?? "")  + "\n"
+            + "Method: " + (request.request?.httpMethod ?? "") + "\n"
+            + "Headers: " + "\(request.request?.allHTTPHeaderFields ?? [:])" + "\n"
+        )
+        print("Authorization: " + (request.request?.headers["Authorization"] ?? ""))
+        print("Body: " + (request.request?.httpBody?.toPrettyPrintedString ?? ""))
+    }
+
+    func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
+        print("===========================🛰 NETWORK Response LOG===========================")
+        print(
+            "URL: " + (request.request?.url?.absoluteString ?? "") + "\n"
+            + "Result: " + "\(response.result)" + "\n"
+            + "StatusCode: " + "\(response.response?.statusCode ?? 0)" + "\n"
+            + "Data: \(response.data?.toPrettyPrintedString ?? "")"
+        )
+    }
+}
+
+extension Data {
+    var toPrettyPrintedString: String? {
+        guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+              let prettyPrintedString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) else { return nil }
+        return prettyPrintedString as String
+    }
+}

--- a/SOLSOL/Network/Base/APIRequestLoader.swift
+++ b/SOLSOL/Network/Base/APIRequestLoader.swift
@@ -1,0 +1,64 @@
+//
+//  APIRequestLoader.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/21.
+//
+
+import Foundation
+
+import Alamofire
+
+class APIRequestLoader<T: TargetType> {
+    private let configuration: URLSessionConfiguration
+    private let apiLogger: APIEventLogger
+    private let session: Session
+
+    init(
+        configuration: URLSessionConfiguration = .default,
+        apiLogger: APIEventLogger
+    ) {
+        self.configuration = configuration
+        self.apiLogger = apiLogger
+        self.session = Session(configuration: configuration, eventMonitors: [apiLogger])
+    }
+
+    func fetchData<M: Decodable>(
+      target: T,
+      responseData: M.Type,
+      completion: @escaping (NetworkResult<M>) -> Void
+    ) {
+        let dataRequest = session.request(target)
+        dataRequest.responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let value = response.value else { return }
+
+                let networkRequest = self.judgeStatus(by: statusCode, value, type: M.self)
+                completion(networkRequest)
+            case .failure:
+                completion(.networkErr)
+            }
+        }
+    }
+
+    private func judgeStatus<M: Decodable>(by statusCode: Int, _ data: Data, type: M.Type) -> NetworkResult<M> {
+        switch statusCode {
+        case 200: return isValidData(data: data, type: M.self)
+        case 401...409: return isValidData(data: data, type: M.self)
+        case 500: return .serverErr
+        default: return .networkErr
+        }
+    }
+
+    private func isValidData<M: Decodable>(data: Data, type: M.Type) -> NetworkResult<M> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(M.self, from: data) else {
+            print("json decoded failed !")
+            return .pathErr
+        }
+
+        return .success(decodedData)
+    }
+}

--- a/SOLSOL/Network/Base/BaseResponse.swift
+++ b/SOLSOL/Network/Base/BaseResponse.swift
@@ -1,0 +1,15 @@
+//
+//  BaseResponse.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/21.
+//
+
+import Foundation
+
+struct BaseResponse<T: Decodable>: Decodable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: T?
+}

--- a/SOLSOL/Network/Base/Config.swift
+++ b/SOLSOL/Network/Base/Config.swift
@@ -1,0 +1,34 @@
+//
+//  Config.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/20.
+//
+
+import Foundation
+
+
+enum Config {
+    enum Keys {
+        enum Plist {
+            static let baseURL = "BASE_URL"
+        }
+    }
+
+    private static let infoDictionary: [String: Any] = {
+        guard let dict = Bundle.main.infoDictionary else {
+            fatalError("plist cannot found !")
+        }
+        return dict
+    }()
+}
+
+
+extension Config {
+    static let baseURL: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.baseURL] as? String else {
+            fatalError("Base URL is not set in plist for this configuration")
+        }
+        return key
+    }()
+}

--- a/SOLSOL/Network/Base/HTTPHeaderField.swift
+++ b/SOLSOL/Network/Base/HTTPHeaderField.swift
@@ -1,0 +1,18 @@
+//
+//  HTTPHeaderField.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/20.
+//
+
+import Foundation
+
+enum HTTPHeaderField: String {
+    case authentication = "Authorization"
+    case contentType = "Content-Type"
+    case acceptType = "Accept"
+}
+
+enum ContentType: String {
+    case json = "Application/json"
+}

--- a/SOLSOL/Network/Base/NetworkResult.swift
+++ b/SOLSOL/Network/Base/NetworkResult.swift
@@ -1,0 +1,17 @@
+//
+//  NetworkResult.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/20.
+//
+
+import Foundation
+
+
+enum NetworkResult<T> {
+    case success(T)     // 서버 통신 성공
+    case requestErr(T)  // 요청에러 발생
+    case pathErr // 경로 에러
+    case serverErr  // 서버 내부 에러
+    case networkErr // 네트워크 연결 실패
+}

--- a/SOLSOL/Network/Base/NetworkService.swift
+++ b/SOLSOL/Network/Base/NetworkService.swift
@@ -6,3 +6,11 @@
 //
 
 import Foundation
+
+final class NetworkService {
+    static let shared = NetworkService()
+
+    private init() {}
+
+    let homeService: HomeServiceProtocol = HomeService(apiLogger: APIEventLogger())
+}

--- a/SOLSOL/Network/Base/NetworkService.swift
+++ b/SOLSOL/Network/Base/NetworkService.swift
@@ -1,0 +1,8 @@
+//
+//  NetworkService.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/21.
+//
+
+import Foundation

--- a/SOLSOL/Network/Base/TargetType.swift
+++ b/SOLSOL/Network/Base/TargetType.swift
@@ -1,0 +1,88 @@
+//
+//  TargetType.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/20.
+//
+
+import Foundation
+
+import Alamofire
+
+protocol TargetType: URLRequestConvertible {
+    var baseURL: String { get }
+    var method: HTTPMethod { get }
+    var path: String { get }
+    var parameters: RequestParams { get }
+}
+
+extension TargetType {
+    var baseURL: String {
+        return Config.baseURL
+    }
+}
+
+
+extension TargetType {
+    func asURLRequest() throws -> URLRequest {
+        let url = try baseURL.asURL()
+        var urlRequest = try URLRequest(
+            url: url.appendingPathComponent(path),
+            method: method
+        )
+
+        urlRequest.setValue(ContentType.json.rawValue, forHTTPHeaderField: HTTPHeaderField.contentType.rawValue)
+
+        switch parameters {
+        case .requestWithBody(let request):
+            let params = request?.toDictionary() ?? [:]
+
+            urlRequest.httpBody = try JSONSerialization.data(withJSONObject: params)
+        case .requestQuery(let request):
+            let params = request?.toDictionary()
+            let queryParams = params?.map {
+                URLQueryItem(name: $0.key, value: "\($0.value)")
+            }
+            var components = URLComponents(
+                string: url.appendingPathComponent(path).absoluteString)
+            components?.queryItems = queryParams
+            urlRequest.url = components?.url
+        case .requestQueryWithBody(let queryRequest, let bodyRequest):
+            let params = queryRequest?.toDictionary()
+            let queryParams = params?.map {
+                URLQueryItem(name: $0.key, value: "\($0.value)")
+            }
+            var components = URLComponents(
+                string: url.appendingPathComponent(path).absoluteString)
+            components?.queryItems = queryParams
+            urlRequest.url = components?.url
+
+            let bodyParams = bodyRequest?.toDictionary() ?? [:]
+
+            urlRequest.httpBody = try JSONSerialization.data(withJSONObject: bodyParams)
+
+        case .requestPlain:
+            break
+        }
+        return urlRequest
+    }
+}
+
+@frozen
+enum RequestParams {
+    case requestPlain
+    case requestWithBody(_ paramter: Encodable?)
+    case requestQuery(_ parameter: Encodable?)
+    case requestQueryWithBody(_ queryParameter: Encodable?, bodyParameter: Encodable?)
+}
+
+extension Encodable {
+    func toDictionary() -> [String: Any] {
+        guard let data = try? JSONEncoder().encode(self),
+              let jsonData = try? JSONSerialization.jsonObject(with: data),
+              let dictionaryData = jsonData as? [String: Any]
+        else { return [:] }
+
+        return dictionaryData
+    }
+}

--- a/SOLSOL/Network/DTO/Home/Request/AccountsListRequestDTO.swift
+++ b/SOLSOL/Network/DTO/Home/Request/AccountsListRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  AccountsListRequestDTO.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/21.
+//
+
+import Foundation
+
+struct AccountsListRequestDTO: Encodable {
+    let memberId: Int
+}

--- a/SOLSOL/Network/DTO/Home/Response/AccountsListResponseDTO.swift
+++ b/SOLSOL/Network/DTO/Home/Response/AccountsListResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  AccountsListResponseDTO.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/21.
+//
+
+import Foundation
+
+// MARK: - AccountsListResponseDTO
+
+struct AccountsListResponseDTO: Decodable {
+    let memberId: Int
+    let id: Int
+    let bank: String
+    let name: String
+    let balance: Int
+    let accountNumber: String
+}

--- a/SOLSOL/Network/Router/Home/HomeTarget.swift
+++ b/SOLSOL/Network/Router/Home/HomeTarget.swift
@@ -1,8 +1,39 @@
 //
-//  homeTarget.swift
+//  HomeTarget.swift
 //  SOLSOL
 //
 //  Created by 김민재 on 2023/05/21.
 //
 
 import Foundation
+
+import Alamofire
+
+enum HomeTarget {
+    case getAccountsList(_ dto: AccountsListRequestDTO)
+}
+
+extension HomeTarget: TargetType {
+
+    var method: HTTPMethod {
+        switch self {
+        case .getAccountsList(_):
+            return .get
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .getAccountsList(_):
+            return "/accounts/"
+        }
+    }
+
+    var parameters: RequestParams {
+        switch self {
+        case .getAccountsList(let dto):
+            return .requestQuery(dto)
+        }
+    }
+
+}

--- a/SOLSOL/Network/Router/Home/HomeTarget.swift
+++ b/SOLSOL/Network/Router/Home/HomeTarget.swift
@@ -1,0 +1,8 @@
+//
+//  homeTarget.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/21.
+//
+
+import Foundation

--- a/SOLSOL/Network/Service/Home/HomeService.swift
+++ b/SOLSOL/Network/Service/Home/HomeService.swift
@@ -6,3 +6,18 @@
 //
 
 import Foundation
+
+protocol HomeServiceProtocol {
+    func getAccountsList(queryDTO: AccountsListRequestDTO, completion: @escaping (NetworkResult<BaseResponse<[AccountsListResponseDTO]>>) -> Void)
+}
+
+
+final class HomeService: APIRequestLoader<HomeTarget>, HomeServiceProtocol {
+    func getAccountsList(queryDTO: AccountsListRequestDTO, completion: @escaping (NetworkResult<BaseResponse<[AccountsListResponseDTO]>>) -> Void) {
+
+        fetchData(
+            target: .getAccountsList(queryDTO),
+            responseData: BaseResponse<[AccountsListResponseDTO]>.self, completion: completion)
+    }
+}
+

--- a/SOLSOL/Network/Service/Home/HomeService.swift
+++ b/SOLSOL/Network/Service/Home/HomeService.swift
@@ -1,0 +1,8 @@
+//
+//  HomeService.swift
+//  SOLSOL
+//
+//  Created by 김민재 on 2023/05/21.
+//
+
+import Foundation

--- a/SOLSOL/Presentation/Home/HomeViewController.swift
+++ b/SOLSOL/Presentation/Home/HomeViewController.swift
@@ -31,6 +31,7 @@ final class HomeViewController: UIViewController {
         super.viewWillAppear(animated)
         
         navigationController?.setNavigationBarHidden(true, animated: true)
+        getAccountsListWithAPI()
     }
     
     func setStyle() {
@@ -165,4 +166,28 @@ extension HomeViewController: TransferTableViewCellProtocol {
 
 
 
+// MARK: Network Example
 
+extension HomeViewController {
+
+    func getAccountsListWithAPI() {
+        let queryDTO = AccountsListRequestDTO(memberId: 1)
+        NetworkService.shared.homeService.getAccountsList(queryDTO: queryDTO) { result in
+            
+            switch result {
+            case .success(let data):
+                guard let data = data.data else {
+                    print("no data")
+                    return
+                }
+                dump(data)
+            default:
+                print("network failure")
+                return
+            }
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#35

## 🚨 작업한 내용 및 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
# Network Layer 설명

# 폴더 구조
<img width="285" alt="Untitled" src="https://github.com/GO-SOPT-SOLSOL/SOLSOL-iOS/assets/60292150/006aba41-ab06-4741-a1ae-dff8dd7da2f2">


## Base

- **Config**: BASE_URL 등 환경 변수들을 가져오기 위함.
- **HTTPHeaderField**: HTTP 요청 시에 들어가는 header값에 대한 namespace
- **NetworkResult**: 서버 통신 결과에 대한 enum.
- **TargetType**:
    - API들의 공통 Endpoint를 가지고 있는 모듈.
    - Alamofire의 URLRequestConvertible 프로토콜을 채택받는 프로토콜. 해당 프로토콜의 asURLRequest 메서드를 구현하여 request할 때 URLRequest객체 커스텀.
- **APIEventLogger**: Alamofire의 EventMonitor 프로토콜을 채택받는 class. Request가 끝나고 Response
- **BaseResponse**: status, success, message, data등의 기본 골격을 가지고 있는 통일된 Response구조체. data가 있을때도 있고 없을때도 있기 때문에 data는 Optional.
- **APIRequestLoader**:
    - Service가 해당 클래스를 상속받아 사용. APIEventLogger를 가진 session을 만들고 Request를 보내고 response를 받는 공통된 메서드를 가지고 있음.
    - 타입 파라미터로 커스텀한 각각의 도메인의 Endpoint (URLConvertible 타입)을 받아서 fetchData메서드의 target의 인자로 받음.
- **NetworkService**: service 객체들을 가지고 있는 싱글톤 객체. service각각의 shared 호출이 아닌, NetworkService.shared를 통해서 접근하는 방식으로 수정.

### DTO (Data Transfer Object)

- **Request**: 요청을 구조체로 넣어서 encode하기 위해서 해당 **encodable** 구조체를 담기 위함.
- **Response**: 응답을 구조체로 넣어서 decode하기 위해서 해당 **decodable** 구조체를 담기 위함.

## Router

- 각각의 도메인에서 사용되는 Endpoint 정의

## Service

- 사용할 때 외부에서 해당 모듈로 접근해서 네트워크 통신.
- 서비스는 APIRequestLoader 클래스를 상속받기 때문에 부모 클래스의 메서드의 세션과 메서드를 가짐.
    - 상속 시 타입 파라미터에 정의한 Target(URLRequest endpoint)를 넣어주면 됨.
- 요청할 때 필요한 dto 구조체를 넘겨주고, decode 후 받을 response 구조체 Network<T>의 타입 파라미터 자리에 넘겨줌.

```swift
import Foundation

protocol HomeServiceProtocol {
    func getAccountsList(queryDTO: AccountsListRequestDTO, completion: @escaping (NetworkResult<BaseResponse<[AccountsListResponseDTO]>>) -> Void)
}

final class HomeService: APIRequestLoader<HomeTarget>, HomeServiceProtocol {
    func getAccountsList(queryDTO: AccountsListRequestDTO, completion: @escaping (NetworkResult<BaseResponse<[AccountsListResponseDTO]>>) -> Void) {

        fetchData(
            target: .getAccountsList(queryDTO),
            responseData: BaseResponse<[AccountsListResponseDTO]>.self, completion: completion)
    }
}
```

# 사용법

예시에 사용한 API: 계좌 목록 조회 API
**http://3.38.1.206/api/accounts/?memberId=1**

## Response Data

```swift
{
    "status": 200,
    "success": true,
    "message": "계좌 목록 조회에 성공했습니다.",
    "data": [
        {
            "id": 4,
            "memberId": 5,
            "name": "하나가 좋은 통장\n",
            "bank": "HANA",
            "accountNumber": "1212-1222-3334",
            "balance": 500000
        }
    ]
}
```

1. Request 시 넣어야할 값이 있을 시(query parameter, body) Encodable을 채택한 구조체 생성. (url에 들어가는 parameter는 구조체 생성 필요 X)

```swift
import Foundation

struct AccountsListRequestDTO: Encodable {
		let memberId: Int
}
```

1. Response DTO 생성

```swift
import Foundation

// MARK: - AccountsListResponseDTO

struct AccountsListResponseDTO: Decodable {
    let id: Int
    let memberID: Int
    let bank: String
    let number: String
    let name: String
    let kind: String
    let budget: Int

    enum CodingKeys: String, CodingKey {
        case id
        case memberID = "memberId"
        case bank, number, name, kind, budget
    }
}
```

1. Router 폴더의 각 도메인, 화면에 해당하는 EndPoint 정의

```swift
//
//  HomeTarget.swift
//  SOLSOL
//
//  Created by 김민재 on 2023/05/21.
//

import Foundation

import Alamofire

enum HomeTarget {
    case getAccountsList(_ dto: AccountsListRequestDTO)
}

extension HomeTarget: TargetType {

    var method: HTTPMethod {
        switch self {
        case .getAccountsList(_):
            return .get
        }
    }

    var path: String {
        switch self {
        case .getAccountsList(_):
            return "/accounts/"
        }
    }

    var parameters: RequestParams {
        switch self {
        case .getAccountsList(let dto):
            return .requestQuery(dto)
        }
    }

}
```

### enum

- 만약 request시의 위의 예시처럼 query나 body 대신 url parameter가 존재한다면, path에 넣어줄 변수도 enum의 연관값에 추가로 받아야함.

### path

- 받은 변수는 path 계산 프로퍼티의 return값에 `“account/\(해당 변수)”` 이런식으로 넣어주면 됨.

### parameters

```swift
@frozen
enum RequestParams {
    case requestPlain
    case requestWithBody(_ paramter: Encodable?)
    case requestQuery(_ parameter: Encodable?)
    case requestQueryWithBody(_ queryParameter: Encodable?, bodyParameter: Encodable?)
}
```

- RequestParam의 종류는 총 4가지
    - requestPlain: Body도 Query도 없는 그냥 URL만 들어가는 요청
    - requestWithBody: Body를 가지고 있는 요청. (GET은 Body가 없음을 유의)
    - requestQuery: Query parameter를 가지고 있는 요청
    - requestQueryWithBody: Query parameter와 함께 Body값도 가지고 있는 요청

사용하고자 하는 API의 명세서를 보고 맞게 설정하면 됨.

1. Service 폴더에 자신의 도메인에 맞는 Service 만들기. (요청 처리하는 부분)

```swift
//
//  HomeService.swift
//  SOLSOL
//
//  Created by 김민재 on 2023/05/21.
//

import Foundation

protocol HomeServiceProtocol {
    func getAccountsList(queryDTO: AccountsListRequestDTO, completion: @escaping (NetworkResult<BaseResponse<[AccountsListResponseDTO]>>) -> Void)
}

final class HomeService: APIRequestLoader<HomeTarget>, HomeServiceProtocol {
    func getAccountsList(queryDTO: AccountsListRequestDTO, completion: @escaping (NetworkResult<BaseResponse<[AccountsListResponseDTO]>>) -> Void) {

        fetchData(
            target: .getAccountsList(queryDTO),
            responseData: BaseResponse<[AccountsListResponseDTO]>.self, completion: completion)
    }
}
```

- protocol 작성 후 해당 프로토콜을 채택하는 class를 만들어 사용.
- `fetchData`메서드의 target에서 받는 인자는 `HomeTarget.getAccountsList(queryDTO)`의 형태와 동일.
- responseData인자에는 BaseResponse<(이곳에 ResponseDataDTO 구조체)>.self 를 통해 타입의 value값을 넘겨줌.
- **BaseResponse<T>, T자리에 []을 통해 감싸준 이유**는 data의 값이 배열이기 때문에. 배열이 아니라 객체라면 []을 감싸줄 필요없음.

```swift
"data": [
        {
            "id": 4,
            "memberId": 5,
            "name": "하나가 좋은 통장\n",
            "bank": "HANA",
            "accountNumber": "1212-1222-3334",
            "balance": 500000
        }
    ]
```

### BaseResponse

```swift
struct BaseResponse<T: Decodable>: Decodable {
    let status: Int
    let success: Bool
    let message: String
    let data: T?
}
```

- data는 null이거나 값이 들어오기 때문에 옵셔널
1. NetworkService에 자신이 만든 Service 객체 추가

```swift
import Foundation

final class NetworkService {
    static let shared = NetworkService()

    private init() {}

    let homeService: HomeServiceProtocol = HomeService(apiLogger: APIEventLogger())
}
```

- **이 때 타입을 Service class위에 작성해줬던 protocol타입으로 명시**

여기까지 구현했다면 끝.

1. 호출시에는 아래와 같이 호출 가능

```swift
// HomeViewController.swift

// MARK: Network Example

extension HomeViewController {

    func getAccountsListWithAPI() {
        let queryDTO = AccountsListRequestDTO(memberId: 1)
        NetworkService.shared.homeService.getAccountsList(queryDTO: queryDTO) { result in
            switch result {
            case .success(let data):
                guard let data = data.data else {
                    print("no data")
                    return
                }
                dump(data)
            default:
                print("network failure")
                return
            }
        }

    }

}
```

- NetworkService.shared.homeService를 통해서 접근 후 네트워크 통신 메서드 호출.

# 결과
<img width="660" alt="image" src="https://github.com/GO-SOPT-SOLSOL/SOLSOL-iOS/assets/60292150/9de5ac13-b3ca-40a6-b0dc-e30936b21488">

- 위에가 요청과 응답에 대한 log
- 아래는 코드상에서 dump 출력 결과

# 정리

1. 요청, 응답에 해당하는 DTO 생성 (요청은 필요시)
2. Target만들기 (Endpoint 커스텀 정의)
3. Service 만들기 (실제 요청하고 응답 받아서 completion으로 넘겨줌.)
4. NetworkService에 Service 객체 추가. **이 때 타입은 프로토콜으로 명시.**
5. NetworkService.shared.~service를 통해서 접근 후 네트워크 통신하기 
6. 끝.


## 📟 관련 이슈
- Resolved: #35 
